### PR TITLE
Refine SuperMemo2 trainer prompt sequencing

### DIFF
--- a/pages/resources/tools.en.md
+++ b/pages/resources/tools.en.md
@@ -64,6 +64,12 @@ Here are several tools that are currently useful for developing the current site
     description="Convert PDF files to plain text format with drag-and-drop interface and progress tracking."
     icon="export.svg"
   %}
+  {% include link-object.html
+    title="SuperMemo2 Concept Trainer"
+    url="/resources/tools/supermemo2-trainer/"
+    description="Progressive web app to learn acronyms and concepts with CSV imports, SuperMemo2 scheduling, and offline support."
+    icon="feather.svg"
+  %}
 </div>
 <style>
 @media (min-width: 700px) {

--- a/pages/resources/tools.md
+++ b/pages/resources/tools.md
@@ -63,6 +63,12 @@ Voici plusieurs outils qui me sont présentement utiles pour le développement d
     description="Convertit les fichiers PDF en format texte brut avec interface glisser-déposer et suivi des progrès."
     icon="export.svg"
   %}
+  {% include link-object.html
+    title="Entraîneur SuperMemo2"
+    url="/resources/tools/supermemo2-trainer/"
+    description="Application web progressive pour mémoriser acronymes et concepts via imports CSV, SuperMemo2 et stockage local."
+    icon="feather.svg"
+  %}
 </div>
 <style>
 @media (min-width: 700px) {

--- a/resources/tools/supermemo2-tool-plan.md
+++ b/resources/tools/supermemo2-tool-plan.md
@@ -1,0 +1,137 @@
+# SuperMemo2 Acronym & Concept Trainer — Project Plan
+
+## 1. Vision & Objectives
+- Provide a progressive web app (PWA) that helps learners master acronyms and concepts using the SuperMemo2 spaced repetition algorithm.
+- Operate fully offline after initial load, persisting card progress in `localStorage`.
+- Allow learners to point to a remotely hosted CSV file as their dynamic content source and support switching sources or resetting progress later.
+
+## 2. Success Criteria
+1. Learners can import cards from a remote CSV (HTTP/HTTPS) with columns: `Acronym`, `Full name`, `Explanation` (header row ignored).
+2. The app implements the SM-2 algorithm, tracking bidirectional prompts among the three fields while tolerating missing values.
+3. Progress, deck configuration, and metadata persist across sessions using `localStorage`.
+4. The UI is a single-page PWA with install prompt, offline caching, and responsive design.
+5. Config page enables changing source URL, resetting learning data, and setting the maximum number of active non-mastered cards (default 20).
+6. Tools listing pages (`pages/resources/tools.md` and `.en.md`) include the new app entry linked from `/resources/tools/`.
+
+## 3. Key Features & User Flows
+### 3.1 First-Time Setup
+1. Prompt user to enter or select a CSV URL.
+2. Fetch CSV, parse rows, build card entities (skip blank rows and tolerate missing fields).
+3. Initialize SM-2 metadata per card (EF=2.5, interval, repetitions, next review date).
+4. Activate up to `maxActive` new cards (default 20) for review queue.
+
+### 3.2 Daily Review Cycle
+- Present card prompts generated from field pairs: 
+  - Acronym ↔ Full name
+  - Acronym ↔ Explanation
+  - Full name ↔ Explanation
+- Skip prompt types when one side is missing; ensure variety by shuffling prompts per session.
+- Provide response reveal and grade buttons (0–5) to feed SM-2 calculation.
+- Update `localStorage` after each review.
+
+### 3.3 Deck Maintenance
+- Automatically pull additional cards from CSV when mastered count drops below `maxActive` threshold.
+- Detect CSV updates by caching `etag/last-modified` if available, with manual refresh trigger in Config.
+- Support append-only CSV updates by remembering the highest processed row index/hash so that newly appended rows become new cards without reprocessing existing progress.
+- Handle fetch failures gracefully and notify users.
+
+### 3.4 Config Page
+- Accessible via header menu/gear icon.
+- Fields:
+  - Source CSV URL input with validation + fetch test.
+  - Max active (non-mastered) cards numeric input.
+  - Buttons: `Refresh Data`, `Reset Progress`, `Export Progress` (optional stretch).
+- Display metadata: last sync date, total cards, mastered count.
+
+### 3.5 PWA & Offline Support
+- Service worker pre-caches shell assets and last-known CSV snapshot.
+- Offer manual "Download latest" control to update cached data.
+- Provide install prompt info and fallback instructions.
+
+## 4. Data Model
+```ts
+interface Card {
+  id: string;            // hash of row content
+  acronym?: string;
+  fullName?: string;
+  explanation?: string;
+  rowIndex: number;      // used to detect newly appended rows
+}
+
+interface Prompt {
+  id: string;            // `${cardId}|${direction}`
+  question: string;
+  answer: string;
+  cardId: string;
+  direction: 'A2F' | 'F2A' | 'A2E' | 'E2A' | 'F2E' | 'E2F';
+}
+
+// Prompts are generated only for field pairs that exist; rows missing fields still form partial decks.
+
+interface Sm2State {
+  repetitions: number;
+  interval: number;      // in days
+  easiness: number;      // EF
+  nextReview: string;    // ISO date
+}
+
+interface StoredProgress {
+  version: 1;
+  sourceUrl: string;
+  maxActive: number;
+  prompts: Record<string, Sm2State>;
+  knownCsvSignature: string; // e.g., etag+length hash
+  lastRowProcessed: number;  // append-only sync marker
+  lastSync: string;
+}
+```
+
+## 5. Technical Stack & Architecture
+- **Framework**: Vanilla JS or lightweight framework (e.g., Svelte, Vue) — preference for lightweight vanilla + Alpine.js style to minimize build setup, aligning with other tools.
+- **Build**: Use existing Jekyll pipeline; place final app under `resources/tools/supermemo2/` with static assets.
+- **Styling**: Reuse site’s utility classes (`assets/css`) or create scoped styles.
+- **CSV Parsing**: Use Papa Parse (via CDN) or custom parser for small size.
+- **State Management**: Single store module managing prompts, review queue, and persistence.
+- **PWA**: Register service worker scoped to app directory, using Workbox CDN or custom caching logic.
+
+## 6. Implementation Phases
+1. **Scaffolding**
+   - Create tool directory with HTML shell, CSS, JS modules, service worker, manifest.
+   - Add navigation entry to `tools.md` and `tools.en.md`.
+2. **CSV Import & Parsing**
+   - Build source selection UI; handle fetch, parse, and transformation into prompts.
+3. **Local Storage Persistence**
+   - Implement storage layer with versioning and migration placeholders.
+4. **Review Engine**
+   - Implement SM-2 logic, prompt scheduling, and review UI components.
+5. **Config Page**
+   - Build settings modal/page with actions.
+6. **PWA Enhancements**
+   - Add manifest, service worker caching, offline messaging.
+7. **Testing & QA**
+   - Focus on structured manual QA sessions covering CSV append updates, missing-field cards, offline mode, and device breakpoints.
+8. **Documentation & Launch**
+   - Update README/tools docs, provide usage instructions, sample CSV.
+
+## 7. Open Questions & Risks
+- Should CSV refresh automatically on app load or rely on manual refresh? (Plan: attempt auto-refresh with grace period, allow manual override.)
+- Access control for CSV? If behind authentication, browser fetch may fail; document requirement for public URLs.
+- Large CSV performance: consider lazy activation or chunked fetch if >2k rows.
+
+## 8. Deliverables
+- Single-page PWA hosted at `/resources/tools/supermemo2/`.
+- Updated tool listings and documentation.
+- Sample CSV hosted alongside the tool for quick testing.
+- Technical notes summarizing SM-2 grading scales and how to reset progress.
+
+## 9. Timeline (Estimate)
+- Week 1: Scaffolding, CSV import, persistence skeleton.
+- Week 2: Review engine, config page, styling.
+- Week 3: PWA enhancements, QA, documentation.
+
+## 10. Future Enhancements (Post-MVP)
+- Tag filtering or category-based study sessions.
+- Import from Google Sheets or GitHub gist automatically.
+- Progress analytics dashboard (graphs, streaks).
+- Optional spaced repetition algorithm tweaking (e.g., FSRS).
+- Support for multimedia fields (images/audio) if CSV expands.

--- a/resources/tools/supermemo2-trainer/app.js
+++ b/resources/tools/supermemo2-trainer/app.js
@@ -1,0 +1,603 @@
+const STORAGE_KEY = 'supermemo2_concept_trainer_v1';
+const MASTERED_INTERVAL_DAYS = 21;
+const VARIANT_SEQUENCE = [
+  'acronym-fullName',
+  'fullName-acronym',
+  'acronym-explanation',
+  'explanation-acronym',
+  'fullName-explanation',
+  'explanation-fullName'
+];
+const VARIANT_PRIORITY = Object.fromEntries(
+  VARIANT_SEQUENCE.map((type, index) => [type, index])
+);
+
+const defaultCardState = () => ({
+  repetition: 0,
+  interval: 0,
+  ef: 2.5,
+  due: Date.now(),
+  lastReviewed: null,
+  active: false,
+  mastered: false,
+  lapses: 0,
+  history: []
+});
+
+const state = {
+  sourceUrl: '',
+  maxActive: 20,
+  cards: {},
+  order: [],
+  lastRowCount: 0,
+  lastSynced: null
+};
+
+let currentCardId = null;
+let showingAnswer = false;
+
+const elements = {
+  promptText: document.getElementById('promptText'),
+  answerText: document.getElementById('answerText'),
+  cardType: document.getElementById('cardType'),
+  revealWrapper: document.getElementById('revealButtonWrapper'),
+  showAnswerButton: document.getElementById('showAnswerButton'),
+  actionButtons: document.getElementById('actionButtons'),
+  studyPanel: document.getElementById('studyPanel'),
+  historyList: document.getElementById('historyList'),
+  activeCount: document.getElementById('activeCount'),
+  dueCount: document.getElementById('dueCount'),
+  masteredCount: document.getElementById('masteredCount'),
+  totalCount: document.getElementById('totalCount'),
+  sourceMeta: document.getElementById('sourceMeta'),
+  activeLimitNote: document.getElementById('activeLimitNote'),
+  nextDueNote: document.getElementById('nextDueNote'),
+  configDialog: document.getElementById('configDialog'),
+  sourceInput: document.getElementById('sourceInput'),
+  maxActiveInput: document.getElementById('maxActiveInput'),
+  syncNote: document.getElementById('syncNote'),
+  statusBanner: document.getElementById('statusBanner'),
+  syncButton: document.getElementById('syncButton'),
+  configButton: document.getElementById('configButton'),
+  applySettingsButton: document.getElementById('applySettingsButton'),
+  resetButton: document.getElementById('resetButton'),
+  closeConfigButton: document.getElementById('closeConfigButton'),
+  actionButtonContainer: document.getElementById('actionButtons'),
+  revealButton: document.getElementById('showAnswerButton')
+};
+
+function closeConfigDialog() {
+  if (!elements.configDialog) return;
+  if (typeof elements.configDialog.close === 'function') {
+    try {
+      elements.configDialog.close();
+      return;
+    } catch (err) {
+      console.warn('dialog.close() unsupported, applying fallback', err);
+    }
+  }
+  elements.configDialog.removeAttribute('open');
+  elements.configDialog.setAttribute('aria-hidden', 'true');
+  elements.configDialog.style.display = 'none';
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      Object.assign(state, parsed);
+      if (state.cards && typeof state.cards === 'object') {
+        Object.values(state.cards).forEach((card) => {
+          if (typeof card.variantOrder !== 'number') {
+            card.variantOrder = VARIANT_PRIORITY[card.type] ?? 0;
+          }
+        });
+      }
+      if (Array.isArray(state.order) && state.order.length) {
+        rebuildCardOrder();
+      }
+    }
+  } catch (err) {
+    console.error('Failed to load saved state', err);
+  }
+}
+
+function persistState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.error('Failed to save state', err);
+  }
+}
+
+function resetProgress() {
+  Object.keys(state.cards).forEach((id) => {
+    const saved = state.cards[id];
+    const fresh = defaultCardState();
+    saved.repetition = fresh.repetition;
+    saved.interval = fresh.interval;
+    saved.ef = fresh.ef;
+    saved.due = fresh.due;
+    saved.lastReviewed = fresh.lastReviewed;
+    saved.active = fresh.active;
+    saved.mastered = fresh.mastered;
+    saved.lapses = fresh.lapses;
+    saved.history = [];
+  });
+  state.lastSynced = Date.now();
+  persistState();
+  showStatus('Progress reset. All cards are new again.');
+  prepareNextCard();
+  updateStats();
+}
+
+function showStatus(message) {
+  elements.statusBanner.textContent = message;
+  elements.statusBanner.classList.add('visible');
+  setTimeout(() => {
+    elements.statusBanner.classList.remove('visible');
+  }, 2600);
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let current = [];
+  let value = '';
+  let inQuotes = false;
+  let i = 0;
+  while (i < text.length) {
+    const char = text[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          value += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        value += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        current.push(value.trim());
+        value = '';
+      } else if (char === '\n' || char === '\r') {
+        if (char === '\r' && text[i + 1] === '\n') {
+          i += 1;
+        }
+        current.push(value.trim());
+        rows.push(current);
+        current = [];
+        value = '';
+      } else {
+        value += char;
+      }
+    }
+    i += 1;
+  }
+  if (value.length > 0 || current.length > 0) {
+    current.push(value.trim());
+    rows.push(current);
+  }
+  return rows.filter(row => row.some(cell => cell && cell.length));
+}
+
+function generateVariations(entry) {
+  const { acronym, fullName, explanation, rowIndex } = entry;
+  const variations = [];
+  const baseId = `row-${rowIndex}`;
+
+  const addVariation = (type, prompt, answer) => {
+    if (!prompt || !answer) return;
+    const id = `${baseId}-${type}`;
+    const variantOrder = VARIANT_PRIORITY[type] ?? variations.length;
+    if (!state.cards[id]) {
+      state.cards[id] = {
+        id,
+        rowIndex,
+        prompt,
+        answer,
+        type,
+        variantOrder,
+        ...defaultCardState()
+      };
+      state.order.push(id);
+    } else {
+      state.cards[id].prompt = prompt;
+      state.cards[id].answer = answer;
+      state.cards[id].type = type;
+      state.cards[id].variantOrder = variantOrder;
+    }
+    variations.push(id);
+  };
+
+  if (acronym && fullName) {
+    addVariation('acronym-fullName', `What does "${acronym}" stand for?`, fullName);
+    addVariation('fullName-acronym', `Which acronym refers to "${fullName}"?`, acronym);
+  }
+  if (acronym && explanation) {
+    addVariation('acronym-explanation', `Explain the concept behind "${acronym}"`, explanation);
+    addVariation('explanation-acronym', `Which acronym matches this explanation?\n\n${explanation}`, acronym);
+  }
+  if (fullName && explanation) {
+    addVariation('fullName-explanation', `What is the explanation for "${fullName}"?`, explanation);
+    addVariation('explanation-fullName', `Which term fits this description?\n\n${explanation}`, fullName);
+  }
+
+  return variations;
+}
+
+function rebuildCardOrder() {
+  const grouped = new Map();
+  Object.values(state.cards).forEach((card) => {
+    if (!grouped.has(card.rowIndex)) {
+      grouped.set(card.rowIndex, []);
+    }
+    grouped.get(card.rowIndex).push(card);
+  });
+
+  const sortedRowIndices = Array.from(grouped.keys()).sort((a, b) => a - b);
+  let maxVariants = 0;
+  sortedRowIndices.forEach((rowIndex) => {
+    const cards = grouped.get(rowIndex);
+    cards.sort((a, b) => (a.variantOrder ?? 0) - (b.variantOrder ?? 0));
+    if (cards.length > maxVariants) {
+      maxVariants = cards.length;
+    }
+  });
+
+  const newOrder = [];
+  for (let column = 0; column < maxVariants; column += 1) {
+    sortedRowIndices.forEach((rowIndex) => {
+      const cards = grouped.get(rowIndex);
+      const card = cards[column];
+      if (card) {
+        newOrder.push(card.id);
+      }
+    });
+  }
+
+  state.order = newOrder;
+}
+
+async function fetchAndMergeCsv(url) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to download CSV: ${response.status} ${response.statusText}`);
+  }
+  const text = await response.text();
+  const rows = parseCsv(text);
+  if (!rows.length) {
+    throw new Error('CSV file is empty.');
+  }
+  const dataRows = rows.slice(1); // skip header
+  let newVariations = 0;
+  state.order = state.order.filter((id) => state.cards[id]);
+  dataRows.forEach((columns, idx) => {
+    const rowIndex = idx;
+    const [acronym = '', fullName = '', explanation = ''] = columns;
+    const entry = {
+      rowIndex,
+      acronym: (acronym || '').trim(),
+      fullName: (fullName || '').trim(),
+      explanation: (explanation || '').trim()
+    };
+    if (!entry.acronym && !entry.fullName && !entry.explanation) {
+      return;
+    }
+    const beforeCount = state.order.length;
+    const ids = generateVariations(entry);
+    const afterCount = state.order.length;
+    newVariations += Math.max(0, afterCount - beforeCount);
+    ids.forEach((id) => {
+      const card = state.cards[id];
+      card.sourceSnapshot = entry;
+    });
+  });
+  rebuildCardOrder();
+  state.lastRowCount = dataRows.length;
+  state.lastSynced = Date.now();
+  persistState();
+  return { totalRows: dataRows.length, newVariations };
+}
+
+function getActiveCards() {
+  return Object.values(state.cards).filter(card => card.active && !card.mastered);
+}
+
+function getDueCards(now = Date.now()) {
+  return Object.values(state.cards).filter(card => card.active && card.due <= now);
+}
+
+function getNewCards() {
+  return state.order.map(id => state.cards[id]).filter(card => !card.active);
+}
+
+function determineNextCard() {
+  const now = Date.now();
+  const dueCards = getDueCards(now);
+  if (dueCards.length) {
+    dueCards.sort((a, b) => a.due - b.due || a.rowIndex - b.rowIndex);
+    return dueCards[0];
+  }
+  const activeCount = getActiveCards().length;
+  if (activeCount < state.maxActive) {
+    const newCards = getNewCards();
+    if (newCards.length) {
+      return newCards[0];
+    }
+  }
+  const futureCards = Object.values(state.cards)
+    .filter(card => card.active)
+    .sort((a, b) => a.due - b.due);
+  return futureCards[0] || null;
+}
+
+function updateStats() {
+  const activeCards = getActiveCards();
+  const dueCards = getDueCards();
+  const masteredCards = Object.values(state.cards).filter(card => card.mastered);
+  const nextCard = determineNextCard();
+
+  elements.activeCount.textContent = activeCards.length.toString();
+  elements.dueCount.textContent = dueCards.length.toString();
+  elements.masteredCount.textContent = masteredCards.length.toString();
+  elements.totalCount.textContent = state.order.length.toString();
+  elements.activeLimitNote.textContent = `Max ${state.maxActive}`;
+
+  if (!nextCard) {
+    elements.nextDueNote.textContent = 'No cards available yet';
+  } else if (nextCard.active && nextCard.due > Date.now()) {
+    const diffMinutes = Math.round((nextCard.due - Date.now()) / 60000);
+    elements.nextDueNote.textContent = diffMinutes <= 0 ? 'Next review imminently' : `Next review in ${diffMinutes} min`;
+  } else if (!nextCard.active) {
+    elements.nextDueNote.textContent = 'Ready to introduce a new card';
+  } else {
+    elements.nextDueNote.textContent = 'Next card ready now';
+  }
+
+  if (state.sourceUrl) {
+    const date = state.lastSynced ? new Date(state.lastSynced) : null;
+    elements.sourceMeta.textContent = date
+      ? `Source: ${state.sourceUrl} (synced ${date.toLocaleString()})`
+      : `Source: ${state.sourceUrl}`;
+  } else {
+    elements.sourceMeta.textContent = 'No source loaded';
+  }
+}
+
+function renderHistory() {
+  const historyItems = [];
+  Object.values(state.cards).forEach(card => {
+    card.history.slice(-5).forEach(entry => {
+      historyItems.push({
+        card,
+        entry
+      });
+    });
+  });
+  historyItems.sort((a, b) => b.entry.reviewedAt - a.entry.reviewedAt);
+  const limited = historyItems.slice(0, 6);
+  elements.historyList.innerHTML = '';
+  limited.forEach(({ card, entry }) => {
+    const li = document.createElement('li');
+    const gradeMap = {
+      0: 'Again',
+      1: 'Fail',
+      2: 'Retry',
+      3: 'Hard',
+      4: 'Good',
+      5: 'Easy'
+    };
+    li.innerHTML = `
+      <span><strong>${card.prompt}</strong></span>
+      <span class="label">${gradeMap[entry.grade] || entry.grade} · ${new Date(entry.reviewedAt).toLocaleTimeString()}</span>
+    `;
+    elements.historyList.appendChild(li);
+  });
+  if (!limited.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No reviews yet.';
+    elements.historyList.appendChild(li);
+  }
+}
+
+function renderCard(card) {
+  if (!card) {
+    elements.promptText.textContent = 'Nothing to review right now.';
+    elements.answerText.textContent = '';
+    elements.answerText.classList.remove('visible');
+    elements.cardType.textContent = '';
+    elements.revealWrapper.style.display = 'none';
+    elements.actionButtons.style.display = 'none';
+    return;
+  }
+  const now = Date.now();
+  if (card.active && card.due > now) {
+    const diffMinutes = Math.round((card.due - now) / 60000);
+    const diffHours = Math.round((card.due - now) / 3600000);
+    const waitMessage = diffMinutes < 60
+      ? `All caught up! Next review unlocks in about ${Math.max(diffMinutes, 1)} minute(s).`
+      : `All caught up! Next review unlocks in about ${Math.max(diffHours, 1)} hour(s).`;
+    elements.promptText.textContent = waitMessage;
+    elements.answerText.textContent = '';
+    elements.answerText.classList.remove('visible');
+    elements.cardType.textContent = '';
+    elements.revealWrapper.style.display = 'none';
+    elements.actionButtons.style.display = 'none';
+    currentCardId = null;
+    showingAnswer = false;
+    return;
+  }
+  currentCardId = card.id;
+  showingAnswer = false;
+  elements.promptText.textContent = card.prompt;
+  elements.answerText.textContent = card.answer;
+  elements.answerText.classList.remove('visible');
+  elements.cardType.textContent = card.type.replace(/[-_]/g, ' ');
+  elements.revealWrapper.style.display = 'flex';
+  elements.actionButtons.style.display = 'none';
+}
+
+function prepareNextCard() {
+  const card = determineNextCard();
+  renderCard(card);
+  updateStats();
+}
+
+function showAnswer() {
+  if (!currentCardId) return;
+  elements.answerText.classList.add('visible');
+  elements.revealWrapper.style.display = 'none';
+  elements.actionButtons.style.display = 'flex';
+  showingAnswer = true;
+}
+
+function applySm2(card, grade) {
+  const now = Date.now();
+  if (grade < 3) {
+    card.repetition = 0;
+    card.interval = 1;
+    card.due = now + 24 * 60 * 60 * 1000;
+    card.ef = Math.max(1.3, card.ef + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02)));
+    card.mastered = false;
+    card.lapses += 1;
+  } else {
+    card.repetition += 1;
+    if (card.repetition === 1) {
+      card.interval = 1;
+    } else if (card.repetition === 2) {
+      card.interval = 6;
+    } else {
+      card.interval = Math.round(card.interval * card.ef);
+    }
+    card.ef = Math.max(1.3, card.ef + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02)));
+    card.due = now + card.interval * 24 * 60 * 60 * 1000;
+    card.mastered = card.interval >= MASTERED_INTERVAL_DAYS;
+  }
+  card.active = true;
+  card.lastReviewed = now;
+  card.history.push({ grade, reviewedAt: now });
+  if (card.history.length > 20) {
+    card.history = card.history.slice(-20);
+  }
+}
+
+function gradeCard(grade) {
+  if (!currentCardId || !showingAnswer) {
+    return;
+  }
+  const card = state.cards[currentCardId];
+  if (!card) {
+    prepareNextCard();
+    return;
+  }
+  applySm2(card, grade);
+  persistState();
+  renderHistory();
+  prepareNextCard();
+}
+
+function attachEventListeners() {
+  elements.showAnswerButton.addEventListener('click', showAnswer);
+  elements.actionButtonContainer.addEventListener('click', (event) => {
+    const grade = event.target?.dataset?.grade;
+    if (grade === undefined) return;
+    gradeCard(Number(grade));
+  });
+  elements.configButton.addEventListener('click', () => {
+    if (typeof elements.configDialog.showModal === 'function') {
+      elements.configDialog.showModal();
+    } else {
+      elements.configDialog.setAttribute('open', 'true');
+      elements.configDialog.removeAttribute('aria-hidden');
+      elements.configDialog.style.display = 'block';
+    }
+    elements.sourceInput.value = state.sourceUrl || '';
+    elements.maxActiveInput.value = state.maxActive;
+    elements.syncNote.textContent = state.lastSynced
+      ? `Last synced ${new Date(state.lastSynced).toLocaleString()}`
+      : 'No sync performed yet';
+  });
+  elements.syncButton.addEventListener('click', async () => {
+    if (!state.sourceUrl) {
+      showStatus('Set a CSV source first.');
+      return;
+    }
+    try {
+      await syncCsv(state.sourceUrl);
+    } catch (err) {
+      console.warn('Sync failed', err);
+    }
+  });
+  elements.applySettingsButton.addEventListener('click', async () => {
+    const url = elements.sourceInput.value.trim();
+    const maxActive = Number(elements.maxActiveInput.value) || state.maxActive;
+    if (!url) {
+      showStatus('Please provide a CSV URL.');
+      return;
+    }
+    state.maxActive = Math.max(1, Math.min(200, Math.round(maxActive)));
+    try {
+      await syncCsv(url);
+      state.sourceUrl = url;
+      persistState();
+      closeConfigDialog();
+    } catch (err) {
+      showStatus(err.message);
+    }
+  });
+  elements.resetButton.addEventListener('click', () => {
+    const confirmed = window.confirm('Reset all progress? This keeps your source but restarts all scheduling.');
+    if (confirmed) {
+      resetProgress();
+    }
+  });
+  elements.closeConfigButton.addEventListener('click', closeConfigDialog);
+}
+
+async function syncCsv(url) {
+  try {
+    showStatus('Syncing CSV…');
+    const results = await fetchAndMergeCsv(url);
+    state.sourceUrl = url;
+    persistState();
+    renderHistory();
+    prepareNextCard();
+    updateStats();
+    elements.syncNote.textContent = `Last synced ${new Date(state.lastSynced).toLocaleString()}`;
+    showStatus(`Sync complete: ${results.totalRows} rows (${results.newVariations} new variations).`);
+    return results;
+  } catch (err) {
+    console.error(err);
+    showStatus(err.message);
+    throw err;
+  }
+}
+
+function bootstrap() {
+  loadState();
+  elements.maxActiveInput.value = state.maxActive;
+  elements.activeLimitNote.textContent = `Max ${state.maxActive}`;
+  if (state.sourceUrl) {
+    elements.sourceMeta.textContent = `Source: ${state.sourceUrl}`;
+    syncCsv(state.sourceUrl).catch(() => {
+      // ignore error, stay offline with cached data
+      prepareNextCard();
+      updateStats();
+      renderHistory();
+    });
+  } else {
+    prepareNextCard();
+    updateStats();
+    renderHistory();
+  }
+}
+
+attachEventListeners();
+bootstrap();

--- a/resources/tools/supermemo2-trainer/example.csv
+++ b/resources/tools/supermemo2-trainer/example.csv
@@ -1,0 +1,101 @@
+Acronym,Full name,Explanation
+API,Application Programming Interface,Contract that defines how software components communicate
+IDE,Integrated Development Environment,Software suite that combines tools for coding debugging and building
+OOP,Object Oriented Programming,Paradigm that organizes code into objects with data and behavior
+TDD,Test Driven Development,Practice of writing tests before implementing code to guide design
+CI,Continuous Integration,Automation that merges and tests code changes frequently
+CD,Continuous Delivery,Practice of keeping software releasable through automated deployment pipelines
+UI,User Interface,Visual layer that users interact with in an application
+UX,User Experience,Overall quality of interactions a user has with a product
+HTTP,Hypertext Transfer Protocol,Application layer protocol for transmitting resources on the web
+HTTPS,Hypertext Transfer Protocol Secure,HTTP encrypted with TLS for secure communication
+REST,Representational State Transfer,Architectural style that uses stateless resources with standard verbs
+CRUD,Create Read Update Delete,Basic operations performed on persistent data
+SQL,Structured Query Language,Language for querying and manipulating relational databases
+NoSQL,Not Only SQL,Category of databases that relax relational models for scalability or flexibility
+JSON,JavaScript Object Notation,Lightweight text format for structured data interchange
+XML,Extensible Markup Language,Markup language for describing structured documents and data
+YAML,YAML Aint Markup Language,Human friendly data serialization language used in configuration
+MVC,Model View Controller,Pattern that separates data presentation and input handling concerns
+MVVM,Model View ViewModel,Pattern that binds view state to view model logic for UI separation
+SPA,Single Page Application,Web app that dynamically updates content without full page reloads
+PWA,Progressive Web App,Web application enhanced with offline caching and installation features
+CDN,Content Delivery Network,Distributed servers that cache content closer to users
+DNS,Domain Name System,System that translates human readable domains into IP addresses
+SSL,Secure Sockets Layer,Legacy protocol for encrypting network connections
+TLS,Transport Layer Security,Cryptographic protocol providing secure communication over networks
+JWT,JSON Web Token,Compact token format for securely transmitting claims between parties
+RBAC,Role Based Access Control,Authorization model that grants permissions through assigned roles
+ACL,Access Control List,Permissions table that specifies allowed operations per subject or object
+CSP,Content Security Policy,Browser policy that restricts sources for loaded resources
+XSS,Cross Site Scripting,Attack where malicious scripts run in a trusted web page
+CSRF,Cross Site Request Forgery,Attack that tricks a user into submitting unwanted requests
+SSRF,Server Side Request Forgery,Attack that coerces a server into making unintended network calls
+SQLI,SQL Injection,Injection attack that manipulates SQL queries via untrusted input
+ORM,Object Relational Mapping,Technique that maps database tables to program objects
+SDK,Software Development Kit,Bundle of tools libraries and docs for building on a platform
+CLI,Command Line Interface,Text based interface for executing program commands
+GUI,Graphical User Interface,Visual interface with windows icons and controls
+KPI,Key Performance Indicator,Metric that tracks progress toward business or technical goals
+SLA,Service Level Agreement,Contract that defines required service performance targets
+SLO,Service Level Objective,Measurable reliability goal derived from an SLA
+SLI,Service Level Indicator,Quantitative measure of a systems performance or reliability
+LTS,Long Term Support,Software release maintained with fixes for an extended period
+LRU,Least Recently Used,Cache eviction policy that removes the entry not accessed for the longest time
+FIFO,First In First Out,Queue discipline that removes the oldest enqueued item first
+LIFO,Last In First Out,Stack discipline that removes the most recent item first
+CPU,Central Processing Unit,Hardware that executes instructions and controls a computer
+GPU,Graphics Processing Unit,Processor optimized for parallel graphical or compute workloads
+RAM,Random Access Memory,Volatile memory used for fast data access by programs
+I/O,Input Output,Exchange of data between a computer system and the outside world
+IPC,Inter Process Communication,Mechanisms that enable processes to exchange data and signals
+RPC,Remote Procedure Call,Protocol that invokes a procedure on a remote system as a local call
+DOM,Document Object Model,Tree representation of structured documents in browsers
+CSS,Cascading Style Sheets,Style sheet language for describing presentation of HTML
+HTML,HyperText Markup Language,Standard markup language for creating web pages
+SASS,Syntactically Awesome Style Sheets,Preprocessor that extends CSS with variables and nesting
+BEM,Block Element Modifier,Naming convention for structuring CSS classes
+OKR,Objectives and Key Results,Goal setting framework that links measurable outcomes to objectives
+ETL,Extract Transform Load,Data pipeline that collects converts and loads data into storage
+ELT,Extract Load Transform,Pipeline that loads raw data before transforming in the destination system
+DAG,Directed Acyclic Graph,Graph structure without cycles often used to model workflows
+BFS,Breadth First Search,Graph traversal strategy that explores neighbors level by level
+DFS,Depth First Search,Graph traversal strategy that explores along a branch before backtracking
+RDBMS,Relational Database Management System,Database system that stores data in related tables with schemas
+ACID,Atomicity Consistency Isolation Durability,Set of properties that guarantee reliable database transactions
+BASE,Basically Available Soft state Eventual consistency,Consistency model that favors availability and eventual convergence
+CAP,Consistency Availability Partition tolerance,Theorem describing trade offs in distributed systems
+CQRS,Command Query Responsibility Segregation,Pattern that separates read and write models for data
+DDD,Domain Driven Design,Approach that models software around the business domain
+BDD,Behavior Driven Development,Development practice that describes features in executable scenarios
+FDD,Feature Driven Development,Iterative process focused on delivering client valued features
+KISS,Keep It Simple Stupid,Principle that encourages simple solutions over complex ones
+YAGNI,You Arent Gonna Need It,Principle warning against building features before they are needed
+DRY,Dont Repeat Yourself,Principle that emphasizes reducing duplication in code and process
+SOLID,SOLID Principles,Set of five object oriented design principles for maintainability
+GRASP,General Responsibility Assignment Software Patterns,Guidelines for assigning responsibilities in object oriented design
+SRP,Single Responsibility Principle,Concept that a module should have one reason to change
+OCP,Open Closed Principle,Design rule to extend behavior without modifying existing code
+LSP,Liskov Substitution Principle,Principle that subtypes must be substitutable for their base types
+ISP,Interface Segregation Principle,Guidance to keep interfaces focused on specific client needs
+DIP,Dependency Inversion Principle,Recommendation to depend on abstractions rather than concretions
+AOP,Aspect Oriented Programming,Paradigm that separates cross cutting concerns into aspects
+SOA,Service Oriented Architecture,Architecture that composes applications from loosely coupled services
+MSA,Microservices Architecture,Style of structuring applications as independently deployable services
+IaC,Infrastructure as Code,Managing infrastructure resources through versioned code definitions
+DevOps,Development and Operations,Culture and practices that integrate software development and IT operations
+SRE,Site Reliability Engineering,Discipline that applies software engineering to operations and reliability
+BFF,Backend for Frontend,Pattern that creates a dedicated backend tailored to a specific frontend
+HATEOAS,Hypermedia As The Engine Of Application State,REST constraint where responses include links for navigation
+CSR,Client Side Rendering,Technique where the browser renders views using client side JavaScript
+SSR,Server Side Rendering,Technique where the server generates HTML for each request
+VCS,Version Control System,Tooling that tracks changes to source code over time
+DVCS,Distributed Version Control System,Version control that allows each clone to contain the full repository history
+SCM,Source Control Management,Processes and tools for tracking and merging code changes
+PR,Pull Request,Proposal to merge code changes into a repository branch
+UAT,User Acceptance Testing,Validation performed by end users to ensure requirements are met
+QA,Quality Assurance,Activities that ensure software meets agreed quality standards
+SDET,Software Development Engineer in Test,Role combining programming skills with testing expertise
+PoC,Proof of Concept,Prototype that validates feasibility of an idea or technology
+MVP,Minimum Viable Product,Smallest product that delivers value and enables feedback
+RFC,Request for Comments,Document that describes standards and protocols for the internet

--- a/resources/tools/supermemo2-trainer/index.html
+++ b/resources/tools/supermemo2-trainer/index.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SuperMemo2 Concept Trainer</title>
+  <meta name="description" content="Progressive web app for learning acronyms and concepts with SuperMemo2 spaced repetition." />
+  <meta name="theme-color" content="#1e293b" />
+  <link rel="manifest" href="./manifest.webmanifest" />
+  <link rel="icon" href="/assets/img/favicon-32x32.png" type="image/png" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8fafc;
+      --fg: #0f172a;
+      --muted: #475569;
+      --accent: #2563eb;
+      --accent-dark: #1d4ed8;
+      --card-bg: #ffffff;
+      --border: #cbd5f5;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: 1.2rem clamp(1rem, 4vw, 2.5rem);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(79, 70, 229, 0.95));
+      color: white;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      box-shadow: 0 12px 40px rgba(15, 23, 42, 0.25);
+      position: sticky;
+      top: 0;
+      z-index: 3;
+    }
+    header h1 {
+      font-size: clamp(1.5rem, 4vw, 2.2rem);
+      margin: 0;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+    header p {
+      margin: 0;
+      opacity: 0.8;
+      max-width: 32rem;
+      line-height: 1.35;
+      font-size: 0.95rem;
+    }
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+    button {
+      padding: 0.65rem 1rem;
+      border-radius: 0.75rem;
+      border: none;
+      cursor: pointer;
+      font-weight: 600;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+    }
+    button.primary {
+      background: white;
+      color: #1d4ed8;
+      box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+    }
+    button.primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+    }
+    button.secondary {
+      background: rgba(255, 255, 255, 0.16);
+      color: white;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+    }
+    button.secondary:hover {
+      background: rgba(255, 255, 255, 0.25);
+    }
+    main {
+      flex: 1 1 auto;
+      padding: clamp(1.5rem, 4vw, 3rem);
+      display: grid;
+      gap: clamp(1.5rem, 2vw, 2.5rem);
+      grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    }
+    @media (max-width: 1050px) {
+      main {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+    .card {
+      background: var(--card-bg);
+      border-radius: 1.25rem;
+      padding: clamp(1.5rem, 2vw, 2.5rem);
+      box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      position: relative;
+    }
+    .card h2 {
+      margin-top: 0;
+      font-size: 1.2rem;
+      letter-spacing: -0.01em;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      background: rgba(37, 99, 235, 0.12);
+      color: #1d4ed8;
+      font-weight: 600;
+    }
+    .prompt-area {
+      margin: 1.25rem 0;
+      padding: 1.25rem;
+      border-radius: 1rem;
+      background: rgba(241, 245, 249, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      min-height: 6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+      font-weight: 600;
+      line-height: 1.4;
+      white-space: pre-wrap;
+    }
+    .answer-area {
+      margin-top: 1rem;
+      padding: 1.25rem;
+      border-radius: 1rem;
+      background: rgba(34, 197, 94, 0.08);
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      color: #14532d;
+      font-size: clamp(1rem, 2vw, 1.25rem);
+      line-height: 1.45;
+      display: none;
+      white-space: pre-wrap;
+    }
+    .answer-area.visible {
+      display: block;
+      animation: fadeIn 0.25s ease;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+      margin-top: 1.5rem;
+    }
+    .actions button {
+      flex: 1 1 9rem;
+      padding: 0.75rem 1rem;
+      font-weight: 600;
+      border-radius: 0.85rem;
+      background: #e2e8f0;
+      color: #0f172a;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+    }
+    .actions button:hover {
+      background: #cbd5f5;
+    }
+    .actions button.strong {
+      background: rgba(37, 99, 235, 0.18);
+      color: #1d4ed8;
+      border: 1px solid rgba(37, 99, 235, 0.35);
+    }
+    .actions button.positive {
+      background: rgba(22, 163, 74, 0.18);
+      color: #0f5132;
+      border: 1px solid rgba(21, 128, 61, 0.35);
+    }
+    .actions button.positive:hover {
+      background: rgba(22, 163, 74, 0.28);
+    }
+    .actions button.weak {
+      background: rgba(239, 68, 68, 0.12);
+      color: #991b1b;
+      border: 1px solid rgba(248, 113, 113, 0.45);
+    }
+    .stats-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+      margin-top: 1.5rem;
+    }
+    .stat-card {
+      padding: 1rem 1.25rem;
+      background: rgba(241, 245, 249, 0.9);
+      border-radius: 0.9rem;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+    .stat-card span.value {
+      font-size: 1.6rem;
+      font-weight: 700;
+      color: #1d4ed8;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 2rem 1rem;
+      border-radius: 1rem;
+      background: rgba(241, 245, 249, 0.7);
+      border: 1px dashed rgba(148, 163, 184, 0.5);
+      color: var(--muted);
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      align-items: center;
+    }
+    .empty-state button {
+      margin-top: 0.75rem;
+    }
+    .history-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+    .history-list li {
+      padding: 0.75rem 1rem;
+      border-radius: 0.75rem;
+      background: rgba(15, 23, 42, 0.04);
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.9rem;
+    }
+    .history-list li span.label {
+      color: var(--muted);
+    }
+    dialog::backdrop {
+      background: rgba(15, 23, 42, 0.55);
+    }
+    dialog {
+      border: none;
+      border-radius: 1.2rem;
+      padding: clamp(1.5rem, 3vw, 2.5rem);
+      max-width: 540px;
+      width: min(95vw, 540px);
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+    }
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1.1rem;
+    }
+    .form-group label {
+      font-weight: 600;
+      color: #1f2937;
+    }
+    .form-group input {
+      padding: 0.65rem 0.75rem;
+      border-radius: 0.75rem;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      background: rgba(248, 250, 252, 0.85);
+    }
+    .form-inline {
+      display: flex;
+      gap: 0.75rem;
+      align-items: flex-end;
+    }
+    .form-inline input[type="number"] {
+      max-width: 7rem;
+    }
+    .config-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+    .link-button {
+      background: none;
+      border: none;
+      color: #2563eb;
+      cursor: pointer;
+      padding: 0;
+      font: inherit;
+      font-weight: 600;
+    }
+    .status-banner {
+      background: rgba(15, 23, 42, 0.85);
+      color: white;
+      padding: 0.75rem 1rem;
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      border-radius: 999px;
+      box-shadow: 0 15px 35px rgba(15, 23, 42, 0.35);
+      display: none;
+      z-index: 10;
+    }
+    .status-banner.visible {
+      display: block;
+      animation: fadeIn 0.2s ease;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>SuperMemo2 Concept Trainer</h1>
+      <p>Import a CSV file of acronyms and concepts, then practice both directions with adaptive spaced repetition.</p>
+    </div>
+    <div class="header-actions">
+      <button class="secondary" id="syncButton" type="button">⟳ Sync latest CSV</button>
+      <button class="primary" id="configButton" type="button">⚙️ Configure</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="card" id="studyPanel">
+      <div id="cardContent">
+        <h2>Today's session <span class="pill" id="cardType"></span></h2>
+        <div class="prompt-area" id="promptText">Select a source CSV to get started.</div>
+        <div class="answer-area" id="answerText"></div>
+        <div class="actions" id="actionButtons" style="display:none;">
+          <button class="weak" data-grade="0">Again</button>
+          <button data-grade="3">Hard</button>
+          <button class="strong" data-grade="4">Good</button>
+          <button class="positive" data-grade="5">Easy</button>
+        </div>
+        <div class="actions" id="revealButtonWrapper">
+          <button class="primary" id="showAnswerButton" type="button">Show answer</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Session overview</h2>
+      <div class="stats-grid">
+        <div class="stat-card">
+          <span class="label">Active (unmastered)</span>
+          <span class="value" id="activeCount">0</span>
+          <small id="activeLimitNote">Max 20</small>
+        </div>
+        <div class="stat-card">
+          <span class="label">Due now</span>
+          <span class="value" id="dueCount">0</span>
+          <small id="nextDueNote">Next card ready now</small>
+        </div>
+        <div class="stat-card">
+          <span class="label">Mastered</span>
+          <span class="value" id="masteredCount">0</span>
+          <small>Total variations secured</small>
+        </div>
+        <div class="stat-card">
+          <span class="label">Total variations</span>
+          <span class="value" id="totalCount">0</span>
+          <small id="sourceMeta">No source loaded</small>
+        </div>
+      </div>
+      <h3 style="margin-top:1.75rem;">Recent answers</h3>
+      <ul class="history-list" id="historyList"></ul>
+    </section>
+  </main>
+
+  <dialog id="configDialog">
+    <form id="configForm" method="dialog">
+      <h2 style="margin-top:0;">Configuration</h2>
+      <p style="color:var(--muted); font-size:0.95rem;">Update your CSV source, adjust the maximum number of non-mastered cards in rotation, or reset your progress.</p>
+      <div class="form-group">
+        <label for="sourceInput">CSV source URL</label>
+        <input type="url" id="sourceInput" name="source" placeholder="https://example.com/acronyms.csv" required />
+        <small id="syncNote" style="color:var(--muted);"></small>
+      </div>
+      <div class="form-group form-inline">
+        <div>
+          <label for="maxActiveInput">Max active cards</label>
+          <input type="number" id="maxActiveInput" name="maxActive" min="1" max="200" step="1" />
+        </div>
+        <button class="secondary" id="applySettingsButton" type="button">Save &amp; sync</button>
+      </div>
+      <div class="form-group">
+        <button class="link-button" id="resetButton" type="button">Reset all progress</button>
+      </div>
+      <div class="config-actions">
+        <button class="secondary" id="closeConfigButton" type="button">Close</button>
+      </div>
+    </form>
+  </dialog>
+
+  <div class="status-banner" id="statusBanner"></div>
+
+  <script type="module" src="./app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw.js').catch(err => {
+          console.error('Service worker registration failed', err);
+        });
+      });
+    }
+  </script>
+</body>
+</html>

--- a/resources/tools/supermemo2-trainer/manifest.webmanifest
+++ b/resources/tools/supermemo2-trainer/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "SuperMemo2 Concept Trainer",
+  "short_name": "SM2 Trainer",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#1e293b",
+  "description": "Review acronyms and concepts with a SuperMemo2 spaced repetition workflow.",
+  "icons": [
+    {
+      "src": "/assets/img/morel.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/assets/img/morel.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/resources/tools/supermemo2-trainer/sw.js
+++ b/resources/tools/supermemo2-trainer/sw.js
@@ -1,0 +1,53 @@
+const CACHE_NAME = 'sm2-trainer-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './app.js',
+  './manifest.webmanifest'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)).catch((err) => {
+      console.error('Cache install failed', err);
+    })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith('sm2-trainer-cache') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(request, cloned).catch(() => {});
+          });
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a SuperMemo2-based concept trainer PWA that imports CSV decks, stores SM2 progress locally, and supports sync of append-only updates
- include offline caching, configurable limits, and tolerant card generation that skips missing CSV columns while preserving other variations
- list the new trainer on the English and French resources/tools pages
- refine explanation prompts, interleave card variation introductions, and harden the configuration dialog close fallback so the modal dismisses reliably across browsers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed40adc97c832ea14b18fcdec25a27