### PR TITLE
Add Principles section with custom layout and styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,12 @@ plugins:
 # paginate_path: "blog/page:num"   # Pagination path › Important for blog page in /blog/ to work
 
 
+# Collections
+collections:
+  principles:
+    output: true
+    permalink: /principles/:name/
+
 # Theme works best with Kramdown (using the table of contents function)
 markdown           : kramdown
 permalink          : /:categories/:title/
@@ -135,6 +141,13 @@ defaults:
       type: "posts"
     values:
       permalink: "/post/:slug/"
+  -
+    scope:
+      path: ""
+      type: "principles"
+    values:
+      layout: principles
+      lang: en
 
 
 

--- a/_includes/principles_sidebar.html
+++ b/_includes/principles_sidebar.html
@@ -1,0 +1,25 @@
+<aside class="menu principles-sidebar-menu">
+  <p class="menu-label">Principles</p>
+  <ul class="menu-list">
+    <li>
+      <a href="/principles/"
+         {% if page.url == '/principles/' %}class="is-active"{% endif %}>
+        All Principles
+      </a>
+    </li>
+  </ul>
+  {% assign sorted_principles = site.principles | sort: "title" %}
+  {% if sorted_principles.size > 0 %}
+  <p class="menu-label">Individual Principles</p>
+  <ul class="menu-list">
+    {% for principle in sorted_principles %}
+    <li>
+      <a href="{{ principle.url }}"
+         {% if page.url == principle.url %}class="is-active"{% endif %}>
+        {{ principle.title }}
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</aside>

--- a/_layouts/principles.html
+++ b/_layouts/principles.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} | Principles — MorelCorp</title>
+  <meta name="description" content="{{ page.teaser }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  <link rel="stylesheet" href="/assets/css/principles-custom.css">
+  {% include _head.html %}
+  <style>
+    #footer, .footer, .site-footer { display: none !important; }
+  </style>
+</head>
+<body>
+  <nav class="navbar" role="navigation" aria-label="main navigation"
+       style="background:#FDF6EC; border-bottom:2px solid #EFC94C; position:relative;">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="/principles/" style="gap:1rem; align-items:center;">
+        <span class="principles-navbar-title">Principles</span>
+      </a>
+      <a role="button" class="navbar-burger principles-burger"
+         aria-label="menu" aria-expanded="false"
+         data-target="principles-sidebar" tabindex="0"
+         style="margin-left:1rem; display:none;">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </a>
+    </div>
+    <div class="navbar-end">
+      <div class="navbar-item">
+        <a class="button is-light"
+           href="/" title="Back to MorelCorp"
+           style="display:flex; align-items:center; gap:0.2rem; padding:0.2rem 0.7rem;">
+          <img src="/assets/img/morel.svg" alt="MorelCorp Logo" class="principles-back-logo">
+          <span class="principles-back-text">Back to MorelCorp</span>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="columns is-gapless" style="min-height:100vh;">
+    <aside id="principles-sidebar"
+           class="column is-2 is-narrow principles-sidebar"
+           style="border-right:1px solid #e8d5b0; min-width:220px; background:#FEF9F0;">
+      {% include principles_sidebar.html %}
+    </aside>
+    <main class="column is-10 p-5 principles-main-content">
+      <section class="container">
+        {{ content }}
+      </section>
+    </main>
+  </div>
+
+  <footer class="has-text-centered p-4"
+          style="background:#08104b; color:#fff; border-top:2px solid #EFC94C; font-size:0.95rem;">
+    <span>&copy; {{ 'now' | date: '%Y' }} MorelCorp &mdash;
+      <a href="/" style="color:#EFC94C; text-decoration:underline;">morelcorp.ca</a>
+    </span>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var burger = document.querySelector('.principles-burger');
+      var sidebar = document.getElementById('principles-sidebar');
+      if (burger && sidebar) {
+        burger.addEventListener('click', function() {
+          sidebar.classList.toggle('is-active');
+        });
+        document.addEventListener('click', function(e) {
+          if (sidebar.classList.contains('is-active') &&
+              !sidebar.contains(e.target) && !burger.contains(e.target)) {
+            sidebar.classList.remove('is-active');
+          }
+        });
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape') sidebar.classList.remove('is-active');
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/_principles/hire-humility-hunger-smarts.md
+++ b/_principles/hire-humility-hunger-smarts.md
@@ -1,0 +1,51 @@
+---
+title: "Hire for Humility, Hunger and Smarts"
+teaser: "The three traits I look for in every hire — and why each one is non-negotiable."
+date: 2026-04-21
+---
+
+# Hire for Humility, Hunger and Smarts
+
+The best hiring framework I've encountered comes from Patrick Lencioni: look for three things — **humility**, **hunger**, and **smarts**. Miss any one of them and the hire will create problems you'll be managing for years.
+
+## Humility
+
+Humble people don't think less of themselves — they think of themselves less. They share credit, admit mistakes, and are genuinely curious about others' perspectives. In practice, this means they're coachable, they make the team around them better, and they don't protect territory at the expense of outcomes.
+
+The absence of humility is the root cause of most team dysfunction I've witnessed. A brilliant engineer who won't hear feedback, a senior manager who can't admit they're wrong — these people corrode culture faster than any process failure.
+
+> Hiring someone arrogant who's a star performer is a trade you almost always regret.
+
+## Hunger
+
+Hungry people don't need to be managed toward the work. They come in early thinking about the problem. They read, experiment, and push past "good enough." They bring initiative the org chart never asked for.
+
+Hunger isn't workaholism. It's intrinsic motivation. The hungry person goes home and keeps thinking. They're driven by the problem, not the clock.
+
+The practical test: what have they done that nobody asked them to do? What did they learn last month, not because a course was assigned, but because they were curious?
+
+## Smarts
+
+This one is about people smarts as much as raw intelligence — maybe more. Can they read a room? Do they ask good questions? Do they know how their words land on others?
+
+Technical smarts matter in technical roles, obviously. But I've seen technically brilliant people fail badly because they couldn't adapt their communication, couldn't build trust, couldn't figure out why their great idea wasn't landing.
+
+The "smart" I look for is situational awareness plus the ability to learn quickly. Not a credential. Not a GPA.
+
+## Why All Three, Not Two
+
+Two out of three creates predictable failure modes:
+
+- **Humble + Hungry, not Smart**: Will work hard and mean well, but leave damage through poor judgement.
+- **Humble + Smart, not Hungry**: Nice to have around, won't move the needle without external pressure.
+- **Hungry + Smart, not Humble**: The most dangerous hire. Capable, ambitious, and convinced they're right. Will optimize for themselves over the team.
+
+The three work as a system. Humility keeps hunger from becoming toxic. Hunger keeps smarts from going to waste. Smarts ensure that effort and goodwill translate into results.
+
+## How I Screen for This
+
+- **Humility**: I look for deflection of credit and acceptance of blame. I ask about a failure. I watch for "I" vs. "we". I notice whether they're curious about *me* during the conversation.
+- **Hunger**: I ask what they've done unprompted. What they've built, read, or changed in the last six months outside their job description. I watch for energy when the topic shifts to hard problems.
+- **Smarts**: I pay attention to how they listen. Do they ask clarifying questions? Can they adjust their explanation based on my reaction? Do they pick up on subtext?
+
+None of this is foolproof. But consistently applying it — and being willing to say no when one of the three is missing — has been the highest-leverage hiring practice I've used.

--- a/_principles/scrum-least-bad-framework.md
+++ b/_principles/scrum-least-bad-framework.md
@@ -1,0 +1,73 @@
+---
+title: "Scrum is the Least Bad Framework"
+teaser: "I've tried them all. Scrum survives not because it's perfect but because it makes the right trade-offs visible."
+date: 2026-04-21
+---
+
+# Scrum is the Least Bad Framework
+
+I've run teams on Scrum, Kanban, SAFe, custom hybrids, and pure chaos. My conclusion: Scrum is the least bad option for most software teams. Not because it's elegant — it isn't — but because its flaws are visible, its feedback loops are short, and its ceremonies create forcing functions that actually matter.
+
+## What Scrum Gets Right
+
+### Timeboxing forces decisions
+
+The sprint is a deadline with teeth. It forces the team to answer the question "what's actually done?" on a regular cadence. Without a timebox, work expands, definitions of done drift, and "almost done" persists indefinitely.
+
+Sprints make incompleteness visible. That visibility is uncomfortable and that discomfort is the point.
+
+### The retrospective institutionalizes learning
+
+Most teams don't get better over time. They accumulate habits and workarounds and stop questioning them. The retrospective is a scheduled moment to ask "are we getting better?" 
+
+It rarely works perfectly — retros can become complaint sessions or rubber stamps. But the ritual matters. The fact that it exists creates permission to name problems. That's rare.
+
+### Velocity is honest feedback
+
+Velocity is a blunt instrument but it's real. Teams can't inflate it without eventually delivering something. It becomes a mirror — not a performance metric, but a calibration tool. After a few sprints, the team has a ground truth about their actual capacity that no amount of estimation optimism can override.
+
+### It distributes ownership
+
+Daily standups, sprint reviews, backlog refinement — Scrum distributes context and decision-making across the team rather than centralizing it in one PM or tech lead. Done well, the whole team understands the "why" behind the work, not just their ticket.
+
+## What Scrum Gets Wrong
+
+### It mistakes ceremonies for outcomes
+
+Scrum's ceremonies are means, not ends. Too many teams treat the sprint planning meeting as the deliverable rather than the thinking it's supposed to generate. The ceremony becomes ritual. The ritual becomes noise.
+
+### Story points invite gaming
+
+Points are supposed to abstract away time. In practice, teams convert them back to hours within a few months. Velocity becomes a proxy for performance, which breaks it as a calibration tool. Management pressure to "increase velocity" is a sign that the abstraction has failed.
+
+### The sprint cadence doesn't fit all work
+
+Two-week sprints make sense for feature development. They make less sense for infrastructure work, research, or creative work with irregular payoffs. Scrum squeezes all work into the same container regardless of fit.
+
+### It's easy to do Scrum badly
+
+The framework is simple enough that teams can follow all the motions without getting any of the benefits. Stand-ups become status reports. Retrospectives become complaint logs. Sprint planning becomes a negotiation over scope rather than a thinking exercise. Bad Scrum is worse than no process because it creates the illusion of structure while providing none of the benefits.
+
+## Why It's Still the Least Bad Option
+
+The alternatives have worse failure modes:
+
+- **Kanban without discipline** becomes a pile of WIP with no forcing function for delivery.
+- **SAFe** imposes so much ceremony that teams spend more time coordinating than building.
+- **"No process"** works for a team of two and collapses at five.
+- **Custom frameworks** require a level of maturity and discipline most teams haven't built yet.
+
+Scrum's ceremonies are annoying but they create real feedback loops. When you run it and something breaks — velocity drops, the review produces nothing, the retro has no actions — you can point at the specific ceremony that failed and fix it. That debuggability is valuable.
+
+## How I Use It
+
+I use Scrum as a baseline and adapt it deliberately:
+
+- Sprint length varies by team maturity and work type (2 weeks for most, 1 week for early-stage)
+- I replace story points with rough t-shirt sizes (S/M/L) or skip estimation on small, similar work
+- I protect the retrospective — it's the first thing that gets cut and the most important thing to keep
+- I treat velocity as a team-internal tool only, never reported upward
+
+The goal isn't Scrum compliance. It's the feedback loops Scrum was designed to create: regular delivery, regular inspection, regular adaptation.
+
+> Any process that delivers working software every two weeks and asks "what did we learn?" is probably fine. Scrum is a reasonable way to get there.

--- a/assets/css/principles-custom.css
+++ b/assets/css/principles-custom.css
@@ -1,0 +1,169 @@
+/* Principles Section */
+
+body {
+  background: #FDF6EC !important;
+}
+
+.principles-navbar-title {
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #08104b;
+  letter-spacing: 0.01em;
+}
+
+.principles-back-logo {
+  height: 2.2rem;
+  width: auto;
+  vertical-align: middle;
+  margin-right: 0.3rem;
+}
+
+.principles-back-text {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+/* Sidebar */
+.principles-sidebar-menu {
+  padding: 2rem 1rem 1rem 1rem;
+}
+
+.principles-sidebar-menu .menu-label {
+  color: #E27A3F;
+  font-weight: 600;
+  margin-top: 1.5rem;
+}
+
+.principles-sidebar-menu .menu-list a.is-active,
+.principles-sidebar-menu .menu-list a:hover {
+  background: #E27A3F;
+  color: #fff;
+  border-radius: 4px;
+}
+
+/* Cards on index page */
+.principles-card {
+  background: #fff;
+  border-left: 4px solid #EFC94C;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(8,16,75,0.07);
+}
+
+.principles-card h2 {
+  font-size: 1.4rem;
+  color: #08104b;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+.principles-card h2 a {
+  color: #08104b;
+  text-decoration: none;
+}
+
+.principles-card h2 a:hover {
+  color: #E27A3F;
+}
+
+.principles-teaser {
+  color: #555;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* Main content typography */
+.principles-main-content {
+  background: #FDF6EC !important;
+  padding: 2rem;
+}
+
+.principles-main-content h1 {
+  color: #08104b;
+  border-bottom: 2px solid #EFC94C;
+  padding-bottom: 0.4rem;
+  margin-bottom: 1.5rem;
+}
+
+.principles-main-content h2 {
+  color: #E27A3F;
+  margin-top: 2rem;
+}
+
+.principles-main-content h3 {
+  color: #08104b;
+  margin-top: 1.5rem;
+}
+
+.principles-main-content blockquote {
+  border-left: 4px solid #45B29D;
+  background: #f0f9f7;
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+  color: #333;
+  font-style: italic;
+}
+
+.principles-main-content blockquote p {
+  margin: 0;
+}
+
+.principles-main-content ul,
+.principles-main-content ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.principles-main-content li {
+  margin-bottom: 0.3rem;
+}
+
+/* Mobile */
+@media (max-width: 900px) {
+  .columns.is-gapless {
+    flex-direction: column;
+  }
+
+  .principles-sidebar {
+    display: none !important;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 80vw;
+    max-width: 320px;
+    background: #FEF9F0;
+    box-shadow: 2px 0 12px rgba(8,16,75,0.12);
+    z-index: 2000;
+    overflow-y: auto;
+    padding-top: 4rem;
+  }
+
+  .principles-sidebar.is-active {
+    display: block !important;
+  }
+
+  .principles-burger {
+    display: inline-block !important;
+    cursor: pointer;
+  }
+
+  .principles-main-content {
+    padding: 1rem;
+  }
+
+  .principles-back-logo {
+    height: 1.5rem;
+    margin-right: 0.2rem;
+  }
+
+  .principles-back-text {
+    font-size: 0.8rem;
+  }
+
+  .principles-navbar-title {
+    font-size: 1.3rem !important;
+  }
+}

--- a/pages/principles/index.md
+++ b/pages/principles/index.md
@@ -1,0 +1,21 @@
+---
+layout: principles
+permalink: /principles/
+title: "Principles"
+teaser: "Personal management and leadership principles — hard-won beliefs about teams, process, and decision-making."
+---
+
+# Principles
+
+These are my working beliefs about managing people, building teams, and running software projects. They're not universal laws — they're the things I've come to rely on through experience, argument, and occasionally being wrong.
+
+I update them as I learn.
+
+{% assign sorted_principles = site.principles | sort: "title" %}
+{% for principle in sorted_principles %}
+<div class="principles-card">
+  <h2><a href="{{ principle.url }}">{{ principle.title }}</a></h2>
+  <p class="principles-teaser">{{ principle.teaser }}</p>
+  <a href="{{ principle.url }}" class="button is-warning is-light is-small">Read &rarr;</a>
+</div>
+{% endfor %}


### PR DESCRIPTION
## Summary
This PR introduces a new "Principles" section to the site, featuring a dedicated layout, custom styling, and initial principle articles. The section provides a curated space for sharing management and leadership philosophies with a clean, focused design.

## Key Changes

- **New Collection**: Added `principles` collection to `_config.yml` with custom output path (`/principles/:name/`)
- **Custom Layout**: Created `_layouts/principles.html` with:
  - Dedicated navbar with back-to-site button
  - Responsive sidebar navigation with mobile burger menu
  - Custom footer
  - Mobile-first responsive design
- **Styling**: Added `assets/css/principles-custom.css` with:
  - Warm color palette (#FDF6EC background, #E27A3F accents, #EFC94C highlights)
  - Card-based design for principle listings
  - Typography hierarchy for content pages
  - Mobile responsive breakpoints (max-width: 900px)
  - Sidebar toggle functionality for mobile
- **Sidebar Component**: Created `_includes/principles_sidebar.html` for navigation
- **Index Page**: Added `pages/principles/index.md` listing all principles with cards
- **Initial Content**: Added two principle articles:
  - "Scrum is the Least Bad Framework"
  - "Hire for Humility, Hunger and Smarts"

## Implementation Details

- The layout uses Bulma CSS framework for grid/responsive structure
- Mobile sidebar uses fixed positioning and JavaScript toggle (click outside or ESC to close)
- Principles are sorted alphabetically in sidebar and index
- Custom styling overrides Bulma defaults with brand colors
- Footer is hidden on principle pages via inline style override
- Collection defaults in `_config.yml` automatically apply the principles layout to all principle documents

https://claude.ai/code/session_01Mj4fqqLDzxZeeecwVNY5aQ