### PR TITLE
Gym in a Box: build version stamp in Codex + network-first HTML

### DIFF
--- a/resources/tools/gym-in-a-box/gym-in-a-box.html
+++ b/resources/tools/gym-in-a-box/gym-in-a-box.html
@@ -335,6 +335,7 @@ canvas#fw{position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-in
   <div id="codex" class="scrim" onclick="if(event.target===this)closeCodex()">
     <div class="sheet">
       <h2><i class="ti ti-book"></i> Codex</h2>
+      <div id="cx-version" class="dim" style="font-size:8px;margin:-8px 0 14px;letter-spacing:1px"></div>
 
       <div class="sec">LEVEL</div>
       <div class="panel">
@@ -382,6 +383,12 @@ canvas#fw{position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-in
 </div>
 
 <script>
+/* Bump on every deploy. Shown at the top of the Codex so you can confirm the
+   freshly deployed build actually reached the browser (the service worker
+   caches hard — if this number is stale you're on a cached copy). Keep it in
+   step with the service-worker CACHE name. */
+const APP_VERSION = 'v6';
+
 /* ============================================================
    DATA — ranks, xp, weights, exercise pool
    ============================================================ */
@@ -1386,6 +1393,7 @@ function closeInfo(){ $('info').classList.remove('open'); }
 function openCodex(){ renderCodex(); $('codex').classList.add('open'); }
 function closeCodex(){ $('codex').classList.remove('open'); }
 function renderCodex(){
+  $('cx-version').textContent='BUILD '+APP_VERSION+' · '+POOL.length+' TRIALS';
   const r=rankObj(state.rank), n=nextRank(state.rank), lp=levelProgress(state.xp);
   $('cx-level').textContent='LVL '+lp.level;
   $('cx-xp').textContent=state.xp.toLocaleString()+' XP';

--- a/resources/tools/gym-in-a-box/service-worker.js
+++ b/resources/tools/gym-in-a-box/service-worker.js
@@ -1,5 +1,5 @@
 // Gym in a Box — offline service worker
-const CACHE = 'gym-in-a-box-v5';
+const CACHE = 'gym-in-a-box-v6';
 
 // Local assets that make up the app shell.
 const SHELL = [
@@ -40,16 +40,36 @@ self.addEventListener('activate', event => {
   self.clients.claim();
 });
 
-// Cache-first, falling back to network and stashing successful GETs so that
-// fonts/webfont files loaded at runtime become available offline next time.
+// Two strategies:
+//  • Navigations / the app HTML → NETWORK-FIRST so a fresh deploy shows up
+//    immediately when online; fall back to the cached shell when offline.
+//  • Everything else (fonts, webfont, icons) → CACHE-FIRST, stashing
+//    successful GETs so they become available offline next time.
 self.addEventListener('fetch', event => {
-  if (event.request.method !== 'GET') return;
-  event.respondWith(
-    caches.match(event.request).then(cached => {
-      if (cached) return cached;
-      return fetch(event.request).then(resp => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  const isHTML = req.mode === 'navigate' ||
+    (req.destination === 'document') ||
+    /\.html(\?|$)/.test(new URL(req.url).pathname);
+
+  if (isHTML) {
+    event.respondWith(
+      fetch(req).then(resp => {
         const copy = resp.clone();
-        caches.open(CACHE).then(c => c.put(event.request, copy)).catch(() => {});
+        caches.open(CACHE).then(c => c.put(req, copy)).catch(() => {});
+        return resp;
+      }).catch(() => caches.match(req).then(c => c || caches.match('./gym-in-a-box.html')))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(req).then(cached => {
+      if (cached) return cached;
+      return fetch(req).then(resp => {
+        const copy = resp.clone();
+        caches.open(CACHE).then(c => c.put(req, copy)).catch(() => {});
         return resp;
       }).catch(() => cached);
     })


### PR DESCRIPTION
Small, standalone fix split out so it can ship ahead of the larger feature PR — it's what makes future deploys actually show up.

## What & why
- **Build version stamp in the Codex.** A small `BUILD v6 · N TRIALS` line now appears under the Codex title. Open the gear icon after a deploy to confirm the fresh build reached the browser instead of a cached copy.
- **Service worker is now network-first for the app HTML/navigations** (cache as offline fallback), while fonts/icons stay cache-first. This is the root-cause fix for "I deployed but don't see changes": the previous cache-first strategy served the stale HTML until the cache name changed.
- Bumped `APP_VERSION` and the service-worker `CACHE` to **v6** to force the stale cache to drop.

## One-time note
The old service worker still controls already-open tabs, so this first time you may need to fully close/reopen the app (or hard-refresh twice) for v6 to take over. After this, network-first means new deploys appear on the next reload.

## Files
- `resources/tools/gym-in-a-box/gym-in-a-box.html`
- `resources/tools/gym-in-a-box/service-worker.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Azzo13zJZYed8zjzJzqewD)_